### PR TITLE
Fix regression where selected parent node is not passed to addEdit location form

### DIFF
--- a/packages/fhir-location-management/src/components/LocationUnitList/index.tsx
+++ b/packages/fhir-location-management/src/components/LocationUnitList/index.tsx
@@ -147,8 +147,9 @@ export const LocationUnitList: React.FC<LocationUnitListProps> = (props: Locatio
                         const queryParams = { parentId: selectedNode.model.nodeId };
                         const searchString = new URLSearchParams(queryParams).toString();
                         history.push(`${URL_LOCATION_UNIT_ADD}?${searchString}`);
+                      } else {
+                        history.push(URL_LOCATION_UNIT_ADD);
                       }
-                      history.push(URL_LOCATION_UNIT_ADD);
                     }}
                   >
                     <PlusOutlined />

--- a/packages/fhir-location-management/src/components/LocationUnitList/tests/__snapshots__/index.test.tsx.snap
+++ b/packages/fhir-location-management/src/components/LocationUnitList/tests/__snapshots__/index.test.tsx.snap
@@ -1,5 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`location-management/src/components/LocationUnitList Passes selected node as the parent location when adding location clicked: user defined root location 1`] = `
+<span
+  title="Ona Office Sub Location"
+>
+  Ona Office Sub Location
+</span>
+`;
+
 exports[`location-management/src/components/LocationUnitList works correctly: first row containing ona office loc details 1`] = `
 <td
   class="ant-table-cell"


### PR DESCRIPTION
On the locations page, selecting a node and then clicking the add location unit, should default to using that location as the intended parent node in the add edit location view. There seems to have been a regression where this was no longer the case in recent releases. 

This pr fixes this behavior and correctly identifies the selected node as the default parent node in the location form.