### PR TITLE
Disable caching when making get requests to the fhir server.

### DIFF
--- a/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
+++ b/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
@@ -219,7 +219,16 @@ describe('dataloaders/FHIRService', () => {
     const fhir = new FHIRServiceClass<fhirR4.CareTeam>('https://test.fhir.org', 'CareTeam');
     const result = await fhir.list();
     await flushPromises();
-    expect(requestMock.mock.calls).toEqual([['CareTeam']]);
+    expect(requestMock.mock.calls).toEqual([
+      [
+        {
+          headers: {
+            'cache-control': 'no-cache',
+          },
+          url: 'CareTeam',
+        },
+      ],
+    ]);
     expect(result).toEqual(fixtures.careTeams);
     // make sure every item of fhirlist returns the CareTeam
     expect(result.entry.every((e) => e.resource.resourceType === 'CareTeam')).toBeTruthy();
@@ -239,7 +248,16 @@ describe('dataloaders/FHIRService', () => {
     // without url params
     const result = await fhir.list({ _count: '100' });
     await flushPromises();
-    expect(requestMock.mock.calls).toEqual([['CareTeam/_search?_count=100']]);
+    expect(requestMock.mock.calls).toEqual([
+      [
+        {
+          headers: {
+            'cache-control': 'no-cache',
+          },
+          url: 'CareTeam/_search?_count=100',
+        },
+      ],
+    ]);
     expect(result).toEqual(fixtures.careTeams);
     // make sure every item of fhirlist returns the CareTeam
     expect(result.entry.every((e) => e.resource.resourceType === 'CareTeam')).toBeTruthy();


### PR DESCRIPTION
closes #1301 , closes #1260, closes #1295 


**Changes included with this PR**
Adds `cache-control: no-cache` header to `GET` requests when using fhir service. https://smilecdr.com/docs/fhir_storage_relational/performance_and_caching.html#controlling-the-query-cache-client

**Checklist**

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are included and passing