### PR TITLE
Fix duplicate location inventory when adding an inventory

### DIFF
--- a/packages/fhir-group-management/src/components/LocationInventory/tests/fixtures.ts
+++ b/packages/fhir-group-management/src/components/LocationInventory/tests/fixtures.ts
@@ -229,6 +229,108 @@ export const locationInventoryList = {
   ],
 };
 
+export const locationInventoryList1384 = {
+  resourceType: 'List',
+  id: '9f4edfe3-ac84-449f-8640-f0d297e75ff5',
+  identifier: [{ use: 'official', value: '9f4edfe3-ac84-449f-8640-f0d297e75ff5' }],
+  status: 'current',
+  code: {
+    coding: [
+      {
+        system: 'http://smartregister.org/codes',
+        code: '22138876',
+        display: 'Supply Inventory List',
+      },
+    ],
+    text: 'Supply Inventory List',
+  },
+  title: 'Service Point',
+  subject: { reference: 'Location/46bb8a3f-cf50-4cc2-b421-fe4f77c3e75d' },
+  entry: [
+    {
+      flag: {
+        coding: [
+          {
+            system: 'http://smartregister.org/codes',
+            code: '22138876',
+            display: 'Supply Inventory List',
+          },
+        ],
+        text: 'Supply Inventory List',
+      },
+      date: '2017-07-13T19:31:00.000Z',
+      item: { reference: 'Group/722cd036-3036-43d6-85e0-d25b22216764' },
+    },
+  ],
+};
+
+export const locationInventoryList1384Bundle = {
+  resourceType: 'Bundle',
+  id: 'df796c9e-002c-47ff-a88f-6b86edca9262',
+  meta: {
+    lastUpdated: '2024-04-03T07:56:54.936+00:00',
+  },
+  type: 'searchset',
+  total: 1,
+  entry: [
+    {
+      resource: locationInventoryList1384,
+      search: {
+        mode: 'match',
+      },
+    },
+  ],
+};
+
+export const updatedLocationInventoryList1 = {
+  resourceType: 'List',
+  id: '9f4edfe3-ac84-449f-8640-f0d297e75ff5',
+  identifier: [{ use: 'official', value: '9f4edfe3-ac84-449f-8640-f0d297e75ff5' }],
+  status: 'current',
+  code: {
+    coding: [
+      {
+        system: 'http://smartregister.org/codes',
+        code: '22138876',
+        display: 'Supply Inventory List',
+      },
+    ],
+    text: 'Supply Inventory List',
+  },
+  entry: [
+    {
+      flag: {
+        coding: [
+          {
+            system: 'http://smartregister.org/codes',
+            code: '22138876',
+            display: 'Supply Inventory List',
+          },
+        ],
+        text: 'Supply Inventory List',
+      },
+      date: '2017-07-13T19:31:00.000Z',
+      item: { reference: 'Group/722cd036-3036-43d6-85e0-d25b22216764' },
+    },
+    {
+      flag: {
+        coding: [
+          {
+            system: 'http://smartregister.org/codes',
+            code: '22138876',
+            display: 'Supply Inventory List',
+          },
+        ],
+        text: 'Supply Inventory List',
+      },
+      date: '2017-07-13T19:31:00.000Z',
+      item: { reference: 'Group/67bb848e-f049-41f4-9c75-3b726664db67' },
+    },
+  ],
+  title: 'Service Point',
+  subject: { reference: 'Location/46bb8a3f-cf50-4cc2-b421-fe4f77c3e75d' },
+};
+
 export const allInventoryList = {
   resourceType: 'List',
   id: 'list-resource-id',

--- a/packages/fhir-group-management/src/components/LocationInventory/utils.tsx
+++ b/packages/fhir-group-management/src/components/LocationInventory/utils.tsx
@@ -348,6 +348,7 @@ export async function getOrCreateList(baseUrl: string, listId: string) {
   const serve = new FHIRServiceClass<IList>(baseUrl, listResourceType);
   return serve.read(listId).catch((err) => {
     if (err.statusCode === 404) {
+      // TODO - do we have to create the template here and then have to upload an updated version
       return createListResource(baseUrl, listId);
     }
     throw err;

--- a/packages/fhir-group-management/src/components/LocationInventory/utils.tsx
+++ b/packages/fhir-group-management/src/components/LocationInventory/utils.tsx
@@ -435,7 +435,6 @@ export const updateListReferencesFactory =
     const payload = cloneDeep(commoditiesListResource);
 
     let existingEntries = payload.entry ?? [];
-    // Issue: the list resource does not need to be added
     if (!editingGroup) {
       existingEntries.push(
         { item: { reference: `${groupResourceType}/${groupResourceId}` } },

--- a/packages/fhir-group-management/src/components/LocationInventory/utils.tsx
+++ b/packages/fhir-group-management/src/components/LocationInventory/utils.tsx
@@ -398,13 +398,19 @@ export async function postLocationInventory(
     const locationInventoryListBundle = await new FHIRServiceClass<IBundle>(
       baseUrl,
       listResourceType
-    ).list({
-      subject: servicePointObj.id,
-      code: `${smartregisterSystemUri}|${servicePointProfileInventoryListCoding.code}`,
-    });
-    let locationInventoryList = getResourcesFromBundle<IList>(locationInventoryListBundle)[0] as
-      | IList
-      | undefined;
+    )
+      .list({
+        subject: servicePointObj.id,
+        code: `${smartregisterSystemUri}|${servicePointProfileInventoryListCoding.code}`,
+      })
+      .catch((err) => {
+        if (err.statusCode === 404) {
+          return undefined;
+        }
+      });
+    let locationInventoryList = locationInventoryListBundle
+      ? getResourcesFromBundle<IList>(locationInventoryListBundle)[0]
+      : undefined;
     locationInventoryList = createUpdateLocationInventoryList(
       listId,
       groupResourceId,

--- a/packages/fhir-helpers/src/constants/codeSystems.ts
+++ b/packages/fhir-helpers/src/constants/codeSystems.ts
@@ -37,7 +37,7 @@ export const inventoryGroupCoding = {
 };
 
 export const servicePointProfileInventoryListCoding = {
-  system: 'http://smartregister.org/',
+  system: smartregisterSystemUri,
   code: '22138876',
   display: 'Supply Inventory List',
 };

--- a/packages/fhir-location-management/src/components/ViewDetails/DetailsTabs/tests/detailsTabs.test.tsx
+++ b/packages/fhir-location-management/src/components/ViewDetails/DetailsTabs/tests/detailsTabs.test.tsx
@@ -232,7 +232,7 @@ test('works correctly - physical location', async () => {
   const inventoryTab = document.querySelector('[data-testid="inventory-tab"]')!;
   // check records shown in table.
   let tableData = [...inventoryTab.querySelectorAll('table tbody tr')].map((tr) => tr.textContent);
-  expect(tableData).toEqual(['Bed nets2/1/20242/1/2024HealthEdit']);
+  expect(tableData).toEqual(['Bed nets2/1/20242/1/2024HealthEdit', 'HealthEdit']);
   const link = inventoryTab.querySelectorAll('a');
   expect(link[0].href).toEqual(
     'http://localhost/location/inventory/d9d7aa7b-7488-48e7-bae8-d8ac5bd09334/1277894c-91b5-49f6-a0ac-cdf3f72cc3d5'


### PR DESCRIPTION
**closes #1384 **

<!-- What issue does this pr close -->

updated the post inventory util function to only create a new location inventory list resource when editing an existing inventory,  not to do so when adding a new inventory to a location that has previous assignments .

Update inventory view details section to see all inventories attached to a location even if sharing products

<!--
list of non-trivial changes included with the PR
-->

**Checklist**

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are included and passing
