### PR TITLE
Refactor content-type header casing to correct override

### DIFF
--- a/packages/react-utils/src/helpers/dataLoaders.ts
+++ b/packages/react-utils/src/helpers/dataLoaders.ts
@@ -59,7 +59,7 @@ export class FHIRServiceClass<T extends IResource> {
   public resourceType: string;
   public signal: AbortSignal;
   public headers: RequestInit['headers'] = {
-    'content-type': 'application/fhir+json',
+    'Content-Type': 'application/fhir+json',
     'cache-control': 'no-cache',
   };
 

--- a/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
+++ b/packages/react-utils/src/helpers/tests/dataLoaders.test.ts
@@ -224,7 +224,7 @@ describe('dataloaders/FHIRService', () => {
         {
           headers: {
             'cache-control': 'no-cache',
-            'content-type': 'application/fhir+json',
+            'Content-Type': 'application/fhir+json',
           },
           url: 'CareTeam',
         },
@@ -254,7 +254,7 @@ describe('dataloaders/FHIRService', () => {
         {
           headers: {
             'cache-control': 'no-cache',
-            'content-type': 'application/fhir+json',
+            'Content-Type': 'application/fhir+json',
           },
           url: 'CareTeam/_search?_count=100',
         },
@@ -317,7 +317,7 @@ describe('dataloaders/FHIRService', () => {
         {
           signal,
           headers: {
-            'content-type': 'application/fhir+json',
+            'Content-Type': 'application/fhir+json',
             'cache-control': 'no-cache',
           },
         },

--- a/setupTests.js
+++ b/setupTests.js
@@ -10,16 +10,6 @@ import { setAllConfigs } from '@opensrp/pkg-config';
 /* eslint-disable @typescript-eslint/naming-convention */
 import { setLogger } from 'react-query';
 
-jest.mock('fhirclient', () => ({
-  client: jest.fn().mockImplementation(() => {
-    return {
-      request: jest.fn(),
-      create: jest.fn(),
-      update: jest.fn(),
-    };
-  }),
-}));
-
 setAllConfigs({
   projectCode: 'core',
   TablesState: {},


### PR DESCRIPTION
**closes #1424**

- Change casing for header keys so that they correctly override the default content-type added by the fhirclient library
-
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] tests are included and passing
- [x] documentation is changed or added
