### PR TITLE
Fix query cache invalidation

### DIFF
--- a/packages/fhir-group-management/src/components/ProductForm/index.tsx
+++ b/packages/fhir-group-management/src/components/ProductForm/index.tsx
@@ -103,7 +103,7 @@ function CommodityForm<
         await postSuccess?.(mutationEffectResponse, isEdit).catch((err) => {
           sendErrorNotification(err.message);
         });
-        queryClient.refetchQueries([groupResourceType]).catch(() => {
+        queryClient.invalidateQueries([groupResourceType]).catch(() => {
           sendInfoNotification(t('Failed to refresh data, please refresh the page'));
         });
         goTo(successUrl);


### PR DESCRIPTION
**closes #1476**

<!-- What issue does this pr close -->

Rplace refecthQuery with proper query invalidation to prevent scheduling of unncessary malformed requests.

<!--
list of non-trivial changes included with the PR
-->
