### PR TITLE
Update getting started doc to latest changes

### DIFF
--- a/app/.env.sample
+++ b/app/.env.sample
@@ -1,48 +1,85 @@
+# =============================================================================
+# BUILD & APP CONFIGURATION
+# =============================================================================
 SKIP_PREFLIGHT_CHECK=true
 GENERATE_SOURCEMAP=false
 INLINE_RUNTIME_CHUNK=false
 IMAGE_INLINE_SIZE_LIMIT=0
 REACT_APP_WEBSITE_NAME=OpenSRP-web
-REACT_APP_DOMAIN_NAME=http://localhost:3000
-REACT_APP_OPENSRP_ACCESS_TOKEN_URL=https://keycloak-stage.smartregister.org/auth/realms/reveal-stage/protocol/openid-connect/token
-REACT_APP_OPENSRP_AUTHORIZATION_URL=https://keycloak-stage.smartregister.org/auth/realms/reveal-stage/protocol/openid-connect/auth
-REACT_APP_OPENSRP_OAUTH_STATE=opensrp
-REACT_APP_OPENSRP_CLIENT_ID=test1
-REACT_APP_ENABLE_OPENSRP_OAUTH=true
-REACT_APP_OPENSRP_API_BASE_URL=https://reveal-stage.smartregister.org/opensrp/rest/
-REACT_APP_OPENSRP_API_V2_BASE_URL=https://reveal-stage.smartregister.org/opensrp/rest/v2/
-REACT_APP_OPENSRP_USER_URL=https://reveal-stage.smartregister.org/opensrp/user-details
-REACT_APP_DISABLE_LOGIN_PROTECTION=false
-REACT_APP_ENABLE_FHIR_USER_MANAGEMENT=false
-REACT_APP_FHIR_API_BASE_URL=https://fhir.labs.smartregister.org/fhir
-REACT_APP_OPENSRP_OAUTH_SCOPES=profile
-REACT_APP_ENABLE_FHIR_HEALTHCARE_SERVICES=false
-REACT_APP_ENABLE_FHIR_TEAMS=false
-REACT_APP_ENABLE_TEAMS_ASSIGNMENT_MODULE=false
-REACT_APP_ENABLE_FHIR_PATIENTS=false
-REACT_APP_MAIN_LOGO_SRC=https://github.com/onaio/fhir-web/blob/main/app/src/assets/images/fhir-web-logo.png?raw=true
-REACT_APP_DEFAULTS_TABLE_PAGE_SIZE=20
+REACT_APP_OPENSRP_WEB_VERSION=$npm_package_version
 
-REACT_APP_ENABLE_FHIR_CARE_TEAM=false
-REACT_APP_DATE_FORMAT=YYYY-MM-DD
-REACT_APP_ENABLE_TEAMS_ASSIGNMENT_MODULE=false
+# =============================================================================
+# DOMAIN
+# =============================================================================
+REACT_APP_DOMAIN_NAME=https://localhost:3000
+
+# =============================================================================
+# KEYCLOAK
+# =============================================================================
+# OAuth endpoints
+REACT_APP_OPENSRP_ACCESS_TOKEN_URL=https://keycloak-stage.smartregister.org/auth/realms/[YOUR_REALM]/protocol/openid-connect/token
+REACT_APP_OPENSRP_AUTHORIZATION_URL=https://keycloak-stage.smartregister.org/auth/realms/[YOUR_REALM]/protocol/openid-connect/auth
+REACT_APP_OPENSRP_USER_URL=https://keycloak-stage.smartregister.org/auth/realms/[YOUR_REALM]/protocol/openid-connect/userinfo
+REACT_APP_KEYCLOAK_API_BASE_URL=https://keycloak-stage.smartregister.org/auth/admin/realms/[YOUR_REALM]
+
+# OAuth configuration
+REACT_APP_OPENSRP_CLIENT_ID=[YOUR_CLIENT_ID]
+REACT_APP_OPENSRP_OAUTH_STATE=opensrp
+REACT_APP_OPENSRP_OAUTH_SCOPES=openid
+REACT_APP_ENABLE_OPENSRP_OAUTH=true
+REACT_APP_BACKEND_ACTIVE=false
+REACT_APP_DISABLE_LOGIN_PROTECTION=false
 REACT_APP_KEYCLOAK_USERS_PAGE_SIZE=20
+
+# =============================================================================
+# FHIR SERVER
+# =============================================================================
+REACT_APP_FHIR_API_BASE_URL=https://fhir.labs.smartregister.org/fhir/
+REACT_APP_OPENSRP_API_BASE_URL=https://fhir-access-proxy.smartregister.org/fhir
+REACT_APP_OPENSRP_API_V2_BASE_URL=https://fhir.labs.smartregister.org/fhir/
+
+# =============================================================================
+# FEATURE FLAGS - USER MANAGEMENT
+# =============================================================================
+REACT_APP_ENABLE_FHIR_USER_MANAGEMENT=true
+REACT_APP_ENABLE_USERS=false
+REACT_APP_ENABLE_USER_GROUPS=false
+REACT_APP_ENABLE_USER_ROLES=false
+REACT_APP_ENABLE_USER_SYNC=true
+
+# =============================================================================
+# FEATURE FLAGS - MODULES
+# =============================================================================
+REACT_APP_ENABLE_FHIR_LOCATIONS=true
+REACT_APP_ENABLE_FHIR_TEAMS=true
+REACT_APP_ENABLE_TEAMS_ASSIGNMENT_MODULE=false
+REACT_APP_ENABLE_FHIR_PATIENTS=true
+REACT_APP_ENABLE_FHIR_CARE_TEAM=true
+REACT_APP_ENABLE_QUEST=true
+REACT_APP_ENABLE_FHIR_GROUP=true
+REACT_APP_ENABLE_FHIR_COMMODITY=true
+REACT_APP_ENABLE_FHIR_HEALTHCARE_SERVICES=false
+
+# =============================================================================
+# UI & LOCALIZATION
+# =============================================================================
+REACT_APP_MAIN_LOGO_SRC=https://github.com/onaio/fhir-web/blob/main/app/src/assets/images/fhir-web-logo.png?raw=true
 REACT_APP_LANGUAGE_CODE=en
 REACT_APP_PROJECT_CODE=core
 REACT_APP_SUPPORTED_LANGUAGES=en,fr
 REACT_APP_ENABLE_LANGUAGE_SWITCHER=true
-# user roles
+REACT_APP_DATE_FORMAT=YYYY-MM-DD
+REACT_APP_DEFAULTS_TABLE_PAGE_SIZE=20
+
+# =============================================================================
+# ADVANCED CONFIGURATION
+# =============================================================================
+REACT_APP_AUTHZ_STRATEGY=keycloak
 REACT_APP_DISABLE_TEAM_MEMBER_REASSIGNMENT=false
+REACT_APP_PRACTITIONER_TO_ORG_ASSIGNMENT_STRATEGY=ONE_TO_MANY
+REACT_APP_FHIR_ROOT_LOCATION_ID=uuid
+REACT_APP_COMMODITIES_LIST_RESOURCE_ID="uuid"
 REACT_APP_PAGINATION_SIZE=1000
 REACT_APP_FHIR_PATIENT_SORT_FIELDS=-_lastUpdated
 REACT_APP_FHIR_PATIENT_BUNDLE_SIZE=5000
-REACT_APP_ENABLE_FHIR_LOCATIONS=false
-REACT_APP_OPENSRP_WEB_VERSION=$npm_package_version
-REACT_APP_SENTRY_CONFIG_JSON={"dsn":"https://public@sentry.example.com/1","release":"1.0.0","environment":"production","tags":{"release-name":"web","commit":"012345"}}
-REACT_APP_ENABLE_QUEST=true
-REACT_APP_ENABLE_FHIR_GROUP=true
-REACT_APP_ENABLE_FHIR_COMMODITY=true
-REACT_APP_COMMODITIES_LIST_RESOURCE_ID="uuid"
-REACT_APP_PRACTITIONER_TO_ORG_ASSIGNMENT_STRATEGY=ONE_TO_MANY
-REACT_APP_AUTHZ_STRATEGY=keycloak
-REACT_APP_FHIR_ROOT_LOCATION_ID=uuid
+REACT_APP_SENTRY_CONFIG_JSON={"dsn":"https://public@sentry.example.com/1" ,"release":"1.0.0","environment":"production","tags":{"release-name":"web","commit":"012345"}}

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,84 +1,499 @@
-# Getting Started With FHIR Web
+# Getting Started With FHIR Web - Complete Local Development Setup
+
+This guide will walk you through setting up fhir-web locally from scratch, including all the necessary tools, SSL certificates, and configuration needed for a working development environment.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Project Setup](#project-setup)
+- [SSL Certificate Setup](#ssl-certificate-setup)
+- [Environment Configuration](#environment-configuration)
+- [Running the Application](#running-the-application)
+- [Testing the User Sync Feature](#testing-the-user-sync-feature)
+- [Development Workflow](#development-workflow)
+- [Troubleshooting](#troubleshooting)
 
 ## Prerequisites
 
-1. [Nodejs](https://nodejs.org/en/)
-2. [Git](https://git-scm.com/)
+Before you begin, ensure you have the following installed:
 
-## Steps
+### 1. Node.js (v16 or higher)
 
-1. Clone the repository
+- **Check if installed:**
+  ```bash
+  node -v
+  ```
+- **Install:** Download from [nodejs.org](https://nodejs.org/) or use a version manager like [nvm](https://github.com/nvm-sh/nvm)
+  ```bash
+  # Using nvm (recommended)
+  nvm install 16
+  nvm use 16
+  ```
 
+### 2. Yarn
+
+- **Check if installed:**
+  ```bash
+  yarn --version
+  ```
+- **Install:**
+  ```bash
+  npm install -g yarn
+  ```
+
+### 3. mkcert (for SSL certificates)
+
+mkcert is needed to generate local SSL certificates for HTTPS development (required for OAuth authentication).
+
+- **macOS:**
+  ```bash
+  brew install mkcert
+  brew install nss  # if you use Firefox
+  mkcert -install
+  ```
+- **Linux:**
+  ```bash
+  # Debian/Ubuntu
+  sudo apt install mkcert
+
+  # Arch
+  sudo pacman -S mkcert
+
+  mkcert -install
+  ```
+- **Windows:**
+  ```bash
+  choco install mkcert
+  mkcert -install
+  ```
+
+### 4. Backend Services Access
+
+You need access to:
+- **Keycloak Server** (OAuth 2.0 authentication)
+- **FHIR Server** (HAPI FHIR Server for data)
+
+**Options:**
+- Use staging servers (credentials required - see Environment Configuration section)
+- Set up local servers using Docker (see [fhir-web Docker documentation](./fhir-web-docker-deployment.md))
+
+## Project Setup
+
+### 1. Navigate to Project Directory
+
+```bash
+# Navigate into the project directory
+cd fhir-web
+```
+
+### 2. Install Dependencies
+
+This project uses Yarn Workspaces and Lerna for monorepo management.
+
+```bash
+yarn install
+```
+
+This will install dependencies for:
+- The main app (`/app`)
+- All packages (`/packages/*`)
+
+**Expected output:** Installation should complete without errors. This may take 2-5 minutes.
+
+### 3. Build All Packages
+
+Before running the app, you need to build all the packages it depends on:
+
+```bash
+yarn lerna:prepublish
+```
+
+**Expected output:** All packages in `/packages` will be compiled. This may take 1-3 minutes.
+
+## SSL Certificate Setup
+
+**Why HTTPS is Required:** OAuth 2.0 redirect URIs typically require HTTPS for security. Running on `http://localhost:3000` will cause authentication failures.
+
+### Generate SSL Certificates
+
+Run the automated script from the project root:
+
+```bash
+yarn generate-certs
+```
+
+This will:
+- Use `mkcert` if available (recommended)
+- Fall back to `openssl` if `mkcert` is not installed
+- Generate two files in project root directory:
+  - `localhost.pem` (certificate)
+  - `localhost-key.pem` (private key)
+
+### Verify Certificate Files
+
+```bash
+ls -la | grep localhost
+```
+
+You should see:
+```
+-rw-r--r--  1 user  staff  1234 Jan 01 12:00 localhost-key.pem
+-rw-r--r--  1 user  staff  5678 Jan 01 12:00 localhost.pem
+```
+
+**Note:** These certificate files are already in `.gitignore` and should NOT be committed to version control.
+
+## Environment Configuration
+
+### 1. Create Environment File
+
+```bash
+cp app/.env.sample app/.env
+```
+
+### 2. Configure Environment Variables
+
+Open `app/.env` in your editor and update the following critical variables:
+
+#### Required OAuth/Keycloak Configuration
+
+```bash
+# IMPORTANT: Must use https:// for OAuth to work
+REACT_APP_DOMAIN_NAME=https://localhost:3000
+
+# Keycloak OAuth URLs - Update with your Keycloak server details
+REACT_APP_OPENSRP_ACCESS_TOKEN_URL=https://your-keycloak-server/auth/realms/YOUR_REALM/protocol/openid-connect/token
+REACT_APP_OPENSRP_AUTHORIZATION_URL=https://your-keycloak-server/auth/realms/YOUR_REALM/protocol/openid-connect/auth
+REACT_APP_OPENSRP_USER_URL=https://your-keycloak-server/auth/realms/YOUR_REALM/protocol/openid-connect/userinfo
+
+# Client ID from your Keycloak client configuration
+REACT_APP_OPENSRP_CLIENT_ID=your-client-id
+
+# Keycloak Admin API (for user management features)
+REACT_APP_KEYCLOAK_API_BASE_URL=https://your-keycloak-server/auth/admin/realms/YOUR_REALM
+```
+
+#### FHIR Server Configuration
+
+```bash
+# FHIR server base URL
+REACT_APP_FHIR_API_BASE_URL=https://your-fhir-server/fhir
+```
+
+#### Authentication Settings
+
+```bash
+# Use direct Keycloak authentication (no Express backend)
+REACT_APP_BACKEND_ACTIVE=false
+
+# Enable OAuth
+REACT_APP_ENABLE_OPENSRP_OAUTH=true
+REACT_APP_OPENSRP_OAUTH_SCOPES=openid
+
+# Disable for local development (optional - not recommended for production)
+REACT_APP_DISABLE_LOGIN_PROTECTION=false
+```
+
+#### Feature Flags
+
+Enable the features you want to use:
+
+```bash
+# User Management (Parent - must be enabled for child menus to work)
+REACT_APP_ENABLE_FHIR_USER_MANAGEMENT=true
+
+# User Management Child Menus (NEW - can be individually controlled)
+REACT_APP_ENABLE_USERS=true
+REACT_APP_ENABLE_USER_GROUPS=true
+REACT_APP_ENABLE_USER_ROLES=true
+REACT_APP_ENABLE_USER_SYNC=true
+
+# Other Features
+REACT_APP_ENABLE_FHIR_LOCATIONS=true
+REACT_APP_ENABLE_FHIR_TEAMS=true
+REACT_APP_ENABLE_FHIR_PATIENTS=true
+REACT_APP_ENABLE_FHIR_CARE_TEAM=true
+REACT_APP_ENABLE_QUEST=true
+REACT_APP_ENABLE_FHIR_GROUP=true
+REACT_APP_ENABLE_FHIR_COMMODITY=true
+```
+
+### 3. Example Configuration (Staging Server)
+
+If you have access to the staging servers, use:
+
+```bash
+REACT_APP_DOMAIN_NAME=https://localhost:3000
+REACT_APP_OPENSRP_ACCESS_TOKEN_URL=https://keycloak-stage.smartregister.org/auth/realms/FHIR_Android/protocol/openid-connect/token
+REACT_APP_OPENSRP_AUTHORIZATION_URL=https://keycloak-stage.smartregister.org/auth/realms/FHIR_Android/protocol/openid-connect/auth
+REACT_APP_OPENSRP_USER_URL=https://keycloak-stage.smartregister.org/auth/realms/FHIR_Android/protocol/openid-connect/userinfo
+REACT_APP_OPENSRP_CLIENT_ID=fhir-web
+REACT_APP_KEYCLOAK_API_BASE_URL=https://keycloak-stage.smartregister.org/auth/admin/realms/FHIR_Android
+REACT_APP_FHIR_API_BASE_URL=https://fhir.labs.smartregister.org/fhir/
+REACT_APP_BACKEND_ACTIVE=false
+REACT_APP_ENABLE_OPENSRP_OAUTH=true
+```
+
+## Running the Application
+
+### Option 1: Quick Start with HTTPS (Recommended)
+
+```bash
+yarn start
+```
+
+This will:
+- Start the React app with HTTPS enabled (configured by default)
+- Use the generated SSL certificates
+- Open at `https://localhost:3000`
+
+**Expected browser behavior:**
+1. Browser will show a security warning (because it's a self-signed certificate)
+2. Click "Advanced" → "Proceed to localhost (unsafe)" or similar
+3. App should load and redirect to Keycloak login
+
+### Option 2: Development Script (Auto-generates certs + starts HTTPS)
+
+```bash
+yarn dev
+```
+
+This will:
+1. Check for certificates and generate if missing
+2. Start the app with HTTPS
+
+### Option 3: Handle CORS Issues with Chrome
+
+If you encounter CORS errors (common when connecting to external APIs), use the Chrome launch script:
+
+**Terminal 1:**
+```bash
+yarn start
+```
+
+**Terminal 2:**
+```bash
+yarn start:chrome
+```
+
+This opens Chrome with:
+- Web security disabled (allows CORS)
+- Separate user profile (won't affect your regular Chrome)
+- All cookies/storage isolated to `/tmp/chrome`
+
+**Alternatively, run the command manually:**
+```bash
+open -n -a "Google Chrome" --args --user-data-dir=/tmp/chrome --disable-web-security
+```
+
+Then navigate to `https://localhost:3000`
+
+### Accessing the Application
+
+Once running, the app will be available at:
+- **URL:** `https://localhost:3000`
+- **Login:** Redirects to your configured Keycloak server
+- **Default page after login:** Dashboard
+
+## Testing the User Sync Feature
+
+The User Sync feature automatically creates missing FHIR resources (Practitioner, Group, PractitionerRole) for Keycloak users.
+
+### 1. Enable Feature Flags
+
+Ensure these are set in your `.env`:
+
+```bash
+REACT_APP_ENABLE_FHIR_USER_MANAGEMENT=true
+REACT_APP_ENABLE_USER_SYNC=true
+```
+
+### 2. Restart the App
+
+```bash
+# Stop the app (Ctrl+C) and restart
+yarn start
+```
+
+### 3. Access User Sync
+
+1. Log in to the application
+2. Navigate to: **Administration → User Management → User Sync**
+3. Click "Scan Users" to check which users need FHIR resources
+4. Click "Sync All" to create missing resources
+
+### 4. Verify Sync
+
+Check your FHIR server for created resources:
+- Practitioners: `https://your-fhir-server/fhir/Practitioner`
+- Groups: `https://your-fhir-server/fhir/Group`
+- PractitionerRoles: `https://your-fhir-server/fhir/PractitionerRole`
+
+## Development Workflow
+
+### Making Changes to Packages
+
+When you modify code in `/packages/*`, you must rebuild that package to see changes:
+
+```bash
+# Example: After editing fhir-group-management
+cd packages/fhir-group-management
+yarn build
+
+# Return to app and refresh browser
+cd ../../app
+```
+
+### Running Tests
+
+```bash
+# Run all tests
+yarn test
+
+# Run tests for specific package
+yarn test packages/fhir-user-sync
+
+# Run app tests only
+cd app
+yarn test
+
+# Watch mode (re-runs on file changes)
+cd app
+yarn test:watch
+```
+
+### Linting
+
+```bash
+# Check for linting issues
+yarn lint
+
+# Auto-fix linting issues
+yarn lint --fix
+```
+
+### Rebuilding All Packages
+
+After pulling latest changes or switching branches:
+
+```bash
+yarn lerna:prepublish
+```
+
+## Troubleshooting
+
+### CORS Errors
+
+**Symptom:** Console shows `Access to XMLHttpRequest blocked by CORS policy`
+
+**Solutions:**
+1. Use the Chrome script: `yarn start:chrome`
+2. Configure CORS on your FHIR/Keycloak server
+3. Use a proxy or CORS browser extension (not recommended)
+
+### SSL Certificate Errors
+
+**Symptom:** Browser refuses to connect, shows "Your connection is not private"
+
+**Solutions:**
+1. Click "Advanced" → "Proceed to localhost"
+2. Regenerate certificates:
    ```bash
-   # with https
-   git clone https://github.com/opensrp/web.git
+   rm localhost.pem localhost-key.pem
+   yarn generate-certs
+   ```
+3. If using Firefox, ensure `nss` is installed with mkcert
 
-   # with ssh
-   git clone git@github.com:opensrp/web.git
+### Keycloak Redirect Errors
+
+**Symptom:** After login, redirected to `http://localhost:3000` instead of `https://localhost:3000`
+
+**Solution:**
+1. Verify `REACT_APP_DOMAIN_NAME=https://localhost:3000` in `.env`
+2. Update Keycloak client configuration:
+   - Valid Redirect URIs: `https://localhost:3000/*`
+   - Web Origins: `https://localhost:3000`
+3. Restart the app
+
+### 401 Unauthorized Errors
+
+**Symptom:** API calls fail with 401 Unauthorized
+
+**Solutions:**
+1. Check Keycloak client configuration allows the OAuth grant type
+2. Verify OAuth scopes in `.env` match Keycloak client scopes
+3. Check access token in browser DevTools → Application → Storage
+4. Ensure user has required permissions in Keycloak
+
+### Package Changes Not Showing
+
+**Symptom:** Modified package code doesn't appear in the running app
+
+**Solution:**
+```bash
+# Rebuild the specific package
+cd packages/[package-name]
+yarn build
+
+# OR rebuild all packages
+cd ../..
+yarn lerna:prepublish
+```
+
+### Port Already in Use
+
+**Symptom:** `Error: listen EADDRINUSE: address already in use :::3000`
+
+**Solutions:**
+1. Kill the process using port 3000:
+   ```bash
+   # macOS/Linux
+   lsof -ti:3000 | xargs kill -9
+
+   # Windows
+   netstat -ano | findstr :3000
+   taskkill /PID [PID] /F
+   ```
+2. Or use a different port:
+   ```bash
+   PORT=3001 yarn start
    ```
 
-2. Cd into the cloned web directory
+### Module Not Found Errors
 
-   ```bash
-   cd web
-   ```
+**Symptom:** `Cannot find module '@opensrp/...'`
 
-3. Create a `.env` file in the main package directory (`/app`)
+**Solutions:**
+```bash
+# Clean install
+rm -rf node_modules
+rm -rf app/node_modules
+rm -rf packages/*/node_modules
+yarn install
+yarn lerna:prepublish
+```
 
-   - You can do this by copying the `/app/.env.sample` file
+### Build Errors After Git Pull
 
-     ```bash
-     cp app/.env.sample app/.env
-     ```
+**Symptom:** Errors after pulling latest changes from git
 
-4. Override the created `.env` values to match your `Keycloak` and `FHIR server` deployment configurations
+**Solution:**
+```bash
+# Clean and reinstall everything
+yarn install
+yarn lerna:prepublish
+```
 
-5. Install dependencies
+## Additional Resources
 
-   ```bash
-   yarn install
-   ```
+- [Environment Variables Reference](/docs/env.md)
+- [Contributing Guide](/docs/CONTRIBUTING.md)
+- [Docker Deployment](/docs/fhir-web-docker-deployment.md)
+- [Internationalization (i18n)](/docs/I18n.md)
+- [Publishing Packages](/docs/publishing.md)
 
-6. Build packages
+## Need Help?
 
-   ```bash
-   yarn lerna:prepublish
-   ```
-
-7. Start the react app
-
-   ```bash
-   yarn start
-   ```
-
-8. The app starts and automatically launches itself on your default browser on [http://localhost:3000](http://localhost:3000)
-
-## Testing
-
-1. Run the `test` command in the root directory to run all test suites for all packages, or inside a specific package directory to only run the package's test suits.
-
-   ```bash
-   yarn test
-   ```
-
-## Notes
-
-1. You can use OAuth 2.0's `Implicit Grant flow` to run the app with direct authentication to Keyckloak. I.e bypassing the express authentication backend.
-
-   - This is done by setting the `REACT_APP_BACKEND_ACTIVE` env to false
-
-     ```bash
-     REACT_APP_BACKEND_ACTIVE=false
-     ```
-
-2. To make a code contribution follow the [contributing documentation](./CONTRIBUTING.md)
-
-3. To see UI changes after making a contribution to a package, cd into the packages' directory and rebuild it using the build command in it's package.json
-
-   - e.g to rebuild the Fhir Group Management package after making code changes to it:
-
-     ```bash
-     cd packages/fhir-group-management
-
-     yarn build
-     ```
+- Check [GitHub Issues](https://github.com/opensrp/web/issues)
+- Consult [Keycloak Documentation](https://www.keycloak.org/documentation)
+- Review [FHIR Documentation](https://www.hl7.org/fhir/)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "private": true,
   "scripts": {
     "start": "lerna run start --scope=@opensrp/web",
+    "start:https": "HTTPS=true SSL_CRT_FILE=localhost.pem SSL_KEY_FILE=localhost-key.pem lerna run start --scope=@opensrp/web",
+    "start:chrome": "open -n -a 'Google Chrome' --args --user-data-dir=/tmp/chrome --disable-web-security",
+    "generate-certs": "if command -v mkcert > /dev/null; then mkcert localhost; else openssl req -x509 -newkey rsa:4096 -keyout localhost-key.pem -out localhost.pem -days 365 -nodes -subj '/CN=localhost'; fi",
+    "dev": "yarn generate-certs && yarn start:https",
     "build": "lerna run build --scope=@opensrp/web",
     "lerna:prepublish": "lerna run build --include-dependencies --stream --no-private",
     "lerna:version": "lerna version --include-merged-tags --conventional-commits --create-release github --sign-git-commit --sign-git-tag",


### PR DESCRIPTION
<!-- What issue does this pr close -->

**Changes included with this PR**

Added a complete, up-to-date local development setup guide (`docs/getting-started.md`) to make it significantly easier for new developers to get fhir-web running locally. The previous documentation was outdated and didn't align with the current codebase structure and setup process.

<!--
list of non-trivial changes included with the PR
-->

**Checklist**

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] tests are included and passing
- [x] documentation is changed or added
- [ ] **Internationalization**:
  - [ ] Ensure all strings are internationalized.
- [ ] **Role-Based Access**:
  - [ ] Verify that all user actions have appropriate role-based access permissions set.
